### PR TITLE
Fixed warnings coming from style function for latest Typst

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,7 +1,7 @@
 #let tree(tag, ..children, child-spacing: 1em, layer-spacing: 2.3em, roof: false, stroke: 0.75pt) = {
   let tag_text = text(tag)
-  style(sty => {
-    let child_widths = children.pos().map(c => measure(c, sty).width)
+  context {
+    let child_widths = children.pos().map(c => measure(c).width)
     let child_xs = ()
     let acc = 0pt
     for width in child_widths {
@@ -13,7 +13,7 @@
 
     let child_nodes = children.pos().enumerate().map(t => {
       let (i, child) = t
-      let child_width = measure(child, sty).width
+      let child_width = measure(child).width
       let x0 = child_xs.at(i) + child_width / 2
       let hi = -layer-spacing + 0.3em
       let lo = -0.3em
@@ -28,7 +28,7 @@
     let child_stack = stack(dir: ltr, spacing: child-spacing, ..child_nodes)
     let layer_stack = stack(dir: ttb, spacing: layer-spacing, tag_text, child_stack)
     block(align(center, layer_stack))
-  })
+  }
 }
 
 #let syntree(code, terminal: (:), nonterminal: (:), child-spacing: 1em, layer-spacing: 2.3em) = {


### PR DESCRIPTION
Currently, in my version of Typst, this package triggers deprecation warnings:

```
warning: `style` is deprecated
   ┌─ @local/syntree:0.2.0/lib.typ:3:2
   │  
 3 │ ╭   style(sty => {
 4 │ │     let child_widths = children.pos().map(c => measure(c, sty).width)
 5 │ │     let child_xs = ()
 6 │ │     let acc = 0pt
   · │
30 │ │     block(align(center, layer_stack))
31 │ │   })
   │ ╰────^
   │  
   = hint: use a `context` expression instead

warning: calling `measure` with a styles argument is deprecated
  ┌─ @local/syntree:0.2.0/lib.typ:4:47
  │
4 │     let child_widths = children.pos().map(c => measure(c, sty).width)
  │                                                ^^^^^^^^^^^^^^^
  │
  = hint: try removing the styles argument

warning: calling `measure` with a styles argument is deprecated
   ┌─ @local/syntree:0.2.0/lib.typ:16:24
   │
16 │       let child_width = measure(child, sty).width
   │                         ^^^^^^^^^^^^^^^^^^^
   │
   = hint: try removing the styles argument
```

This PR adapts to more recent version of Typst:

```bash
typst --version
# typst 0.11.0 (8bf2df82)
```