### PR TITLE
do not draw a stack for a singleton (childless) `tree`

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,4 +1,8 @@
 #let tree(tag, ..children, child-spacing: 1em, layer-spacing: 2.3em, roof: false, stroke: 0.75pt) = {
+  // If there are no children, do not draw a stack.
+  if children.len() == 0 {
+    return tag
+  }
   let tag-text = text(tag)
   context {
     let child-widths = children.pos().map(c => measure(c).width)

--- a/lib.typ
+++ b/lib.typ
@@ -1,6 +1,6 @@
 #let tree(tag, ..children, child-spacing: 1em, layer-spacing: 2.3em, roof: false, stroke: 0.75pt) = {
   // If there are no children, do not draw a stack.
-  if children.len() == 0 {
+  if children.pos().len() == 0 {
     return tag
   }
   let tag-text = text(tag)


### PR DESCRIPTION
fixes #20 by simply returning the head for childless trees:

```typst
#tree[head]
```
is now equal to
```typst
head
```
