### PR TITLE
Add support for HTML output

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -27,7 +27,12 @@
 
     let child-stack = stack(dir: ltr, spacing: child-spacing, ..child-nodes)
     let layer-stack = stack(dir: ttb, spacing: layer-spacing, tag-text, child-stack)
-    block(align(center, layer-stack))
+    let rendered-tree = block(align(center, layer-stack))
+    if "html" in dictionary(std) and target() == "html" {
+      html.frame(rendered-tree)
+    } else {
+      rendered-tree
+    }
   }
 }
 


### PR DESCRIPTION
HTML support for Typst is here! This adds a conditional check to see if we are compiling to the HTML output format, and if so, wraps the rendered tree in an [HTML frame](https://typst.app/docs/reference/html/frame/). This renders it as an SVG, which is as correct as it gets in the HTML context -- not everything should be an HTML frame (ex. @retroflexivity's examples package should instead ship some extra semantic grid content, [like what `cheq` does with `<input>`](https://github.com/OrangeX4/typst-cheq/blob/500c61a8/lib.typ#L225)), but syntax trees definitely should be.

With this patch applied, the examples in `examples` can be compiled with the `--features html` and `--format html` flags. Then they'll work inside `figures` and other elements, for example, 
<img width="497" height="347" alt="image" src="https://github.com/user-attachments/assets/59d07990-2ea9-4037-8944-72e6f2431b94" />

(HTML rendering)
